### PR TITLE
Añadir detección de onda desconocida en determinarTipoOnda

### DIFF
--- a/desafio.cpp
+++ b/desafio.cpp
@@ -133,9 +133,16 @@ void determinarTipoOnda(){
     strcpy(tipoOnda, "Senoidal");
   }
   
-  if (esSenoidal) Serial.println("Onda Senoidal");
-  if (esCuadrada) Serial.println("Onda Cuadrada");
-  if (esTriangular) Serial.println("Onda Triangular");
+  if (esSenoidal) {
+    Serial.println("Onda Senoidal");
+  } else if (esCuadrada) {
+    Serial.println("Onda Cuadrada");
+  } else if (esTriangular) {
+    Serial.println("Onda Triangular");
+  } else {
+    strcpy(tipoOnda, "Desconocido");
+    Serial.println("Onda Desconocida");
+  }
 
   delay(1000);
 }


### PR DESCRIPTION
- Se agregó una condición para identificar si los datos no coinciden con los patrones de onda conocidos (senoidal, cuadrada o triangular).
- Si no se detecta ninguna forma de onda, se marca el tipo como "Desconocido" y se imprime en el Serial.